### PR TITLE
Revert breaking change for HA integration

### DIFF
--- a/pytomorrowio/pytomorrowio.py
+++ b/pytomorrowio/pytomorrowio.py
@@ -196,8 +196,7 @@ class TomorrowioV4:
         if timestep not in VALID_TIMESTEPS:
             raise InvalidTimestep(f"{timestep} is not a valid 'timestep' parameter")
         fields = process_v4_fields(fields, timestep)
-        if timestep > ONE_HOUR:
-            fields = self.convert_fields_to_measurements(fields)
+        fields = self.convert_fields_to_measurements(fields)
 
         params: Dict[str, Any] = {
             "fields": fields,


### PR DESCRIPTION
@raman325, while reviewing the HA integration today, I realized that I had previously introduced a breaking change soft of related to your `MAX_FIELDS` changes. Sorry about that.

Note that requesting Min, Max and Avg for hourly or smaller timesteps doesn't make a lot of sense since they will all have the same values. But that's necessary since a single call is being made to retrieve all forecast data. And it will probably cause `MAX_FIELDS` to be exceeded.