### PR TITLE
Set sane defaults for max requests/day and remaining requests/sec

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,11 +23,6 @@ async def create_session(
     status: HTTPStatus = HTTPStatus.OK,
 ):
     """Create aiohttp session that returns results from a file"""
-    if not headers:
-        headers = {}
-    if "X-RateLimit-Remaining-Second" not in headers:
-        headers["X-RateLimit-Remaining-Second"] = "1"
-
     ns = SimpleNamespace(
         file_names=[file_name] if isinstance(file_name, str) else file_name,
         index=0,

--- a/tests/test_pytomorrowio.py
+++ b/tests/test_pytomorrowio.py
@@ -61,7 +61,7 @@ async def test_raises_malformed_request(aiohttp_client):
         ONE_HOUR, [TYPE_POLLEN, TYPE_PRECIPITATION, TYPE_WEATHER]
     )
 
-    assert api.max_requests_per_day is None
+    assert api.max_requests_per_day == 100
     assert api.num_api_requests == 0
 
     with pytest.raises(MalformedRequestException):
@@ -78,7 +78,7 @@ async def test_raises_invalid_api_key(aiohttp_client):
         ONE_HOUR, [TYPE_POLLEN, TYPE_PRECIPITATION, TYPE_WEATHER]
     )
 
-    assert api.max_requests_per_day is None
+    assert api.max_requests_per_day == 100
     assert api.num_api_requests == 0
 
     with pytest.raises(InvalidAPIKeyException):
@@ -110,7 +110,7 @@ async def test_raises_rate_limited(aiohttp_client):
         ONE_HOUR, [TYPE_POLLEN, TYPE_PRECIPITATION, TYPE_WEATHER]
     )
 
-    assert api.max_requests_per_day is None
+    assert api.max_requests_per_day == 100
     assert api.num_api_requests == 0
 
     with pytest.raises(RateLimitedException):


### PR DESCRIPTION
We can make things simpler for ourselves and for downstream consumers if we have defaults for the header values.