### PR TITLE
Fix some potential bugs and add a masked API key property

### DIFF
--- a/pytomorrowio/const.py
+++ b/pytomorrowio/const.py
@@ -6,8 +6,8 @@ HEADERS = {"content-type": "application/json"}
 
 MAX_FIELDS_PER_REQUEST = 55
 
-HEADER_DAILY_API_LIMIT = "X-RateLimit-Limit-day"
-HEADER_REMAINING_CALLS_IN_SECOND = "X-RateLimit-Remaining-second"
+HEADER_DAILY_API_LIMIT = "X-RateLimit-Limit-Day"
+HEADER_REMAINING_CALLS_IN_SECOND = "X-RateLimit-Remaining-Second"
 
 DAILY = "daily"
 HOURLY = "hourly"

--- a/pytomorrowio/const.py
+++ b/pytomorrowio/const.py
@@ -6,8 +6,8 @@ HEADERS = {"content-type": "application/json"}
 
 MAX_FIELDS_PER_REQUEST = 55
 
-HEADER_DAILY_API_LIMIT = "X-RateLimit-Limit-Day"
-HEADER_REMAINING_CALLS_IN_SECOND = "X-RateLimit-Remaining-Second"
+HEADER_DAILY_API_LIMIT = "X-RateLimit-Limit-day"
+HEADER_REMAINING_CALLS_IN_SECOND = "X-RateLimit-Limit-second"
 
 DAILY = "daily"
 HOURLY = "hourly"

--- a/pytomorrowio/const.py
+++ b/pytomorrowio/const.py
@@ -7,7 +7,7 @@ HEADERS = {"content-type": "application/json"}
 MAX_FIELDS_PER_REQUEST = 55
 
 HEADER_DAILY_API_LIMIT = "X-RateLimit-Limit-day"
-HEADER_REMAINING_CALLS_IN_SECOND = "X-RateLimit-Limit-second"
+HEADER_REMAINING_CALLS_IN_SECOND = "X-RateLimit-Remaining-second"
 
 DAILY = "daily"
 HOURLY = "hourly"

--- a/pytomorrowio/pytomorrowio.py
+++ b/pytomorrowio/pytomorrowio.py
@@ -119,7 +119,7 @@ class TomorrowioV4:
             "units": self.unit_system,
         }
         self._headers = {**HEADERS, "apikey": self.api_key}
-        self._rate_limits = CIMultiDict()
+        self._rate_limits: CIMultiDict = CIMultiDict()
         self._num_api_requests: int = 0
 
     @property

--- a/pytomorrowio/pytomorrowio.py
+++ b/pytomorrowio/pytomorrowio.py
@@ -218,7 +218,7 @@ class TomorrowioV4:
             raise CantConnectException() from error
 
         self._rate_limits = CIMultiDict(
-            {k: int(v) for k, v in resp.headers.items() if "limit" in k.lower()}
+            {k: int(v) for k, v in resp.headers.items() if "ratelimit" in k.lower()}
         )
 
         if resp.status in (HTTPStatus.OK, HTTPStatus.PARTIAL_CONTENT):

--- a/tests/test_pytomorrowio.py
+++ b/tests/test_pytomorrowio.py
@@ -112,6 +112,7 @@ async def test_raises_rate_limited(aiohttp_client):
 
     assert api.max_requests_per_day == 100
     assert api.num_api_requests == 0
+    assert api.api_key_masked == "*********_key"
 
     with pytest.raises(RateLimitedException):
         await api.forecast_hourly(available_fields)


### PR DESCRIPTION
Potential bugs fixed:
- force no compression when sending data since the server occasionally seems to respond with a 400 `Can not decode content-encoding: gzip`
- Switch from json.dumps to using aiohttp's internal serialization logic
- Remove filter for content-type check on response - we will handle a parsing exception anyway

Feature:
- Add masked API key property. We want to mask the key in the coordinator name so logs can more easily be posted