### PR TITLE
Simple prototype to discover the time steps that an API key supports

### DIFF
--- a/pytomorrowio/exceptions.py
+++ b/pytomorrowio/exceptions.py
@@ -8,12 +8,12 @@ class TomorrowioException(Exception):
         self.args = args
 
         if error := kwargs.pop("error", None):
-            self.error_code: int = error.get("code")
-            self.error_type: str = error.get("type")
-            self.error_message: str = error.get("message")
+            self.error_code = error.get("code")
+            self.error_type = error.get("type")
+            self.error_message = error.get("message")
 
         if headers := kwargs.pop("headers", None):
-            self.headers: dict[str, str] = dict(headers)
+            self.headers = dict(headers)
 
 
 class MalformedRequestException(TomorrowioException):

--- a/pytomorrowio/exceptions.py
+++ b/pytomorrowio/exceptions.py
@@ -4,6 +4,17 @@
 class TomorrowioException(Exception):
     """Base Exception class for pytomorrowio."""
 
+    def __init__(self, *args, **kwargs):
+        self.args = args
+
+        if error := kwargs.pop("error", None):
+            self.error_code: int = error.get("code")
+            self.error_type: str = error.get("type")
+            self.error_message: str = error.get("message")
+
+        if headers := kwargs.pop("headers", None):
+            self.headers: dict[str, str] = dict(headers)
+
 
 class MalformedRequestException(TomorrowioException):
     """Raised when request was malformed."""

--- a/pytomorrowio/pytomorrowio.py
+++ b/pytomorrowio/pytomorrowio.py
@@ -514,7 +514,9 @@ class TomorrowioV4:
         timesteps = [5, 15, 30, 60, 24 * 60]
         for index, timestep in enumerate(timesteps):
             try:
-                TomorrowioV4.forecast_nowcast(self, ["temperature"], timestep=timestep)
+                await TomorrowioV4.forecast_nowcast(
+                    self, ["temperature"], timestep=timestep
+                )
                 return timesteps[index:]
             except InvalidAPIKeyException as e:
                 if e.error_code == 403003:

--- a/pytomorrowio/pytomorrowio.py
+++ b/pytomorrowio/pytomorrowio.py
@@ -521,6 +521,7 @@ class TomorrowioV4:
             except InvalidAPIKeyException as e:
                 if e.error_code == 403003:
                     continue
+                raise e
         return []
 
 


### PR DESCRIPTION
This is a simple prototype to discover the time steps that an API key supports. Due to the overhead of making a few API calls, this should probably be done one time only in the config_flow and saved in the config_entry.

The return value of this function is currently a list of valid time steps. It could instead be the smallest time step that worked--whichever value works better with the HA integration.

We could also discover which fields are supported by an API key using the same approach.