### PR TITLE
Added evapotranspiration field from core weather API

### DIFF
--- a/pytomorrowio/fields.py
+++ b/pytomorrowio/fields.py
@@ -113,6 +113,11 @@ FIELDS_V4 = {
         measurements=ALL_MEASUREMENTS,
         type=TYPE_SOLAR,
     ),
+    "evapotranspiration": FieldDefinition(
+        max_timestep=ONE_DAY,
+        measurements=ALL_MEASUREMENTS,
+        type=TYPE_SOLAR,
+    ),
     "visibility": FieldDefinition(
         max_timestep=ONE_DAY,
         measurements=ALL_MEASUREMENTS,

--- a/tests/const.py
+++ b/tests/const.py
@@ -65,6 +65,7 @@ REALTIME_FIELDS_GREATER_THAN_MAX = [
 CORE_FIELDS = [
     "temperature",
     "temperatureApparent",
+    "evapotranspiration",
     "dewPoint",
     "humidity",
     "windSpeed",


### PR DESCRIPTION
The only changes are adding a field option for evapotranspiration to .fields.py and ./tests/const.py

I ran a quick test and the API responds without error using my free key. (Although I'm on Windows and have to use the Selector event loop to get asyncio to stop complaining) 

Here's an example of a 3 day forecast using the async forecast_daily function.
```
results = asyncio.run(tom.forecast_daily(fields, duration=timedelta(days=2)))
print(results)

[{'startTime': '2024-06-09T10:00:00Z', 'values': {'evapotranspiration': 0.025}}, {'startTime': '2024-06-10T10:00:00Z', 'values': {'evapotranspiration': 0.028}}, {'startTime': '2024-06-11T10:00:00Z', 'values': {'evapotranspiration': 0.028}}]
```